### PR TITLE
Pretty basic GIT_EPROMISED implementation

### DIFF
--- a/include/git2/errors.h
+++ b/include/git2/errors.h
@@ -59,6 +59,7 @@ typedef enum {
 	GIT_EINDEXDIRTY     = -34,	/**< Unsaved changes in the index would be overwritten */
 	GIT_EAPPLYFAIL      = -35,	/**< Patch application failed */
 	GIT_EMISSING        = -36,  /**< Encountered tree-entry not backed by object */
+	GIT_EPROMISED       = -37,  /**< Tree-entry in a promisor-packfile not backed by object */
 } git_error_code;
 
 /**

--- a/src/object.c
+++ b/src/object.c
@@ -485,6 +485,8 @@ int git_object_lookup_bypath(
 	}
 
 	error = git_tree_entry_to_object(out, git_object_owner(treeish), entry);
+	if (error == GIT_EMISSING)
+		return git_odb__error_missing_or_promised(entry->oid);
 
 cleanup:
 	git_tree_entry_free(entry);

--- a/src/odb.h
+++ b/src/odb.h
@@ -126,6 +126,12 @@ int git_odb__error_notfound(
 int git_odb__error_missing(const git_oid *oid);
 
 /*
+ * Generate a GIT_EMISSING or GIT_EPROMISED error for the ODB,
+ * depending on whether the last object was read from a promisor packfile.
+ */
+int git_odb__error_missing_or_promised(const git_oid *oid);
+
+/*
  * Generate a GIT_EAMBIGUOUS error for the ODB.
  */
 int git_odb__error_ambiguous(const char *message);

--- a/src/odb_loose.c
+++ b/src/odb_loose.c
@@ -17,6 +17,7 @@
 #include "filebuf.h"
 #include "object.h"
 #include "zstream.h"
+#include "threadstate.h"
 
 #include "git2/odb_backend.h"
 #include "git2/types.h"
@@ -619,6 +620,7 @@ static int loose_backend__read(void **buffer_p, size_t *len_p, git_object_t *typ
 		error = git_odb__error_notfound("no matching loose object",
 			oid, GIT_OID_HEXSZ);
 	} else if ((error = read_loose(&raw, &object_path)) == 0) {
+		GIT_THREADSTATE->last_read_object_flags = 0;
 		*buffer_p = raw.data;
 		*len_p = raw.len;
 		*type_p = raw.type;

--- a/src/pack.c
+++ b/src/pack.c
@@ -15,6 +15,7 @@
 #include "odb.h"
 #include "oid.h"
 #include "oidarray.h"
+#include "threadstate.h"
 
 /* Option to bypass checking existence of '.keep' files */
 bool git_disable_pack_keep_file_checks = false;
@@ -698,6 +699,8 @@ int git_packfile_unpack(
 	git_mutex_unlock(&p->lock);
 	if (error < 0)
 		return error;
+
+	GIT_THREADSTATE->pack_promisor = p->pack_promisor;
 
 	/*
 	 * TODO: optionally check the CRC on the packfile

--- a/src/threadstate.h
+++ b/src/threadstate.h
@@ -14,6 +14,12 @@ typedef struct {
 	git_error error_t;
 	git_buf error_buf;
 	char oid_fmt[GIT_OID_HEXSZ+1];
+    union {
+        struct {
+            unsigned pack_promisor:1;
+        };
+        unsigned last_read_object_flags;
+    };
 } git_threadstate;
 
 extern int git_threadstate_global_init(void);

--- a/tests/object/lookupmissing.c
+++ b/tests/object/lookupmissing.c
@@ -66,12 +66,13 @@ void test_object_lookupmissing__missing_with_promisor(void)
 	 * so probably is available at the remote (ie, a partial clone) */
 
 	/* Path -> object. */
-	/* TODO: add a new error code for this - EPROMISED. */
-	cl_assert_equal_i(GIT_EMISSING,
+	cl_assert_equal_i(GIT_EPROMISED,
 		git_object_lookup_bypath(&g_result_object, (git_object*)g_root_tree,
 			"files/second/large_file", GIT_OBJECT_ANY));
 
-	/* Path -> tree-entry -> object. */
+	/* Path -> tree-entry -> object.
+	 * We can't tell if this is missing or promised since we can't recognise
+	 * which packfile the supplied tree-entry came from. */
 	cl_git_pass(git_tree_entry_bypath(&g_result_entry, g_root_tree,
 		"files/second/large_file"));
 	/* TODO: add a new error code for this - EPROMISED. */


### PR DESCRIPTION
![](https://media2.giphy.com/media/wFtUK7Jw058u4/giphy.gif)

Splits GIT_EMISSING error into two errors -

- GIT_EMISSING - we took some object that is present in the ODB, and tried to resolve one of its children, but the child was not present in the ODB - and, it is not a GIT_EPROMISED situation - see below:
- GIT_EPROMISED - same as GIT_EMISSING but the object that is present in the ODB was found in a promisor packfile. So presumably, the missing child is "promised" and can be found at the appropriate promisor remote.

Note that these errors can be a little fuzzy / best effort - you have to do the right thing to get the most useful error:

- If you lookup some object by path, you might get a GIT_EPROMISED error, but then if you look up that same object by ID, you can only get a GIT_ENOTFOUND error. This is because there is no straight-forward way to look up the parent of an object by ID, so we don't know if the object of the ID supplied is missing, promised, or doesn't exist at all. Path-lookups, on the other hand, resolve each parent in turn until you get to the object you need. Same applies to GIT_EMISSING. 

- If you look up an object by path, you can get an GIT_EPROMISED error even for an object that doesn't exist at all, if you look up a path where part of the path is missing+promised. Eg, if you lookup the path `a/b/c/d/e` and the tree at `a/b/c` is missing+promised, you'll still get a GIT_EPROMISED even though there's no way to know if `a/b/c/d/e` exists at all.

Uses thread-local to pass relevant info back up the call-chain without having to change the API, which is the same API that is used externally. I could have split the API into an public-facing API and an internal API which has extra info, but this was a much smaller change. WDYT?